### PR TITLE
不具合修正

### DIFF
--- a/project/Engine/Module/World/Collision/CollisionCallbackManager.cpp
+++ b/project/Engine/Module/World/Collision/CollisionCallbackManager.cpp
@@ -18,8 +18,8 @@ void CollisionCallbackManager::begin() {
 	}
 }
 
-void CollisionCallbackManager::callback(const CallbackInfo& lhs, const CallbackInfo& rhs, bool result) {
-	SortedPair<std::string> callbackKey = SortedPair<std::string>(lhs.first, rhs.first);
+void CollisionCallbackManager::callback(CallbackInfo lhs, CallbackInfo rhs, bool result) {
+	CallbackMapKey callbackKey = CallbackMapKey(lhs.first, rhs.first);
 	if (!callbackFunctions.contains(callbackKey)) {
 		return;
 	}

--- a/project/Engine/Module/World/Collision/CollisionCallbackManager.h
+++ b/project/Engine/Module/World/Collision/CollisionCallbackManager.h
@@ -13,16 +13,16 @@
 
 class CollisionCallbackManager {
 protected:
-	using CallbackMapKey = SortedPair<std::string>;
+	using CallbackMapKey = SortedPair<const std::string>;
 	struct CallbackFunctions {
-		std::function<void(const BaseCollider* const, const BaseCollider* const)> onContinue;
-		std::function<void(const BaseCollider* const, const BaseCollider* const)> onEnter;
-		std::function<void(const BaseCollider* const, const BaseCollider* const)> onExit;
+		std::function<void(BaseCollider* const, BaseCollider* const)> onContinue;
+		std::function<void(BaseCollider* const, BaseCollider* const)> onEnter;
+		std::function<void(BaseCollider* const, BaseCollider* const)> onExit;
 	};
 
 private:
-	using CallbackInfo = std::pair<std::string, const BaseCollider*>;
-	using CollisionRecentKeyType = SortedPair<const BaseCollider*>;
+	using CallbackInfo = std::pair<const std::string&, BaseCollider* const>;
+	using CollisionRecentKeyType = SortedPair<BaseCollider* const>;
 
 public:
 	CollisionCallbackManager() = default;
@@ -32,7 +32,7 @@ public:
 
 public:
 	void begin();
-	void callback(const CallbackInfo& lhs, const CallbackInfo& rhs, bool result);
+	void callback(CallbackInfo lhs, CallbackInfo rhs, bool result);
 
 protected:
 	std::unordered_map<CallbackMapKey, CallbackFunctions> callbackFunctions;
@@ -40,3 +40,15 @@ protected:
 private:
 	std::unordered_map<CollisionRecentKeyType, std::bitset<2>> collisionRecent;
 };
+
+#define __CALLBACK_PLACEHOLDERS_12 std::placeholders::_1, std::placeholders::_2
+#define __CALLBACK_ARGUMENT_DEFAULT BaseCollider* const, BaseCollider* const
+
+
+/*
+Callbackメモ
+
+callback用関数で呼び出される引数の順序は、
+CollisionManager::collisionの引数順序と同じ
+
+*/

--- a/project/Engine/Utility/Template/SortedPair.h
+++ b/project/Engine/Utility/Template/SortedPair.h
@@ -16,7 +16,7 @@
 template<std::totally_ordered T>
 class SortedPair {
 public:
-	SortedPair() = default;
+	constexpr SortedPair() = default;
 	~SortedPair() = default;
 
 	SortedPair(const SortedPair&) = default;
@@ -25,26 +25,26 @@ public:
 	SortedPair& operator=(SortedPair&&) = default;
 
 public:
-	bool operator==(const SortedPair& rhs) const {
+	constexpr bool operator==(const SortedPair& rhs) const {
 		return values.first == rhs.values.first && values.second == rhs.values.second;
 	}
-	bool operator!=(const SortedPair& rhs) const {
+	constexpr bool operator!=(const SortedPair& rhs) const {
 		return !(*this == rhs);
 	}
 
 public:
-	SortedPair(const T& val1, const T& val2);
+	constexpr SortedPair(const T& val1, const T& val2);
 
 public:
-	const T& small() const { return values.first; };
-	const T& big() const { return values.second; };
+	constexpr T& small() const { return values.first; };
+	constexpr T& big() const { return values.second; };
 
 private:
 	std::pair<T, T> values;
 };
 
 template<std::totally_ordered T>
-inline SortedPair<T>::SortedPair(const T& val1, const T& val2) :
+constexpr SortedPair<T>::SortedPair(const T& val1, const T& val2) :
 	values(
 		val1 <= val2 ?
 		std::make_pair(val1, val2) :

--- a/project/Engine/Utility/Tools/Hash.h
+++ b/project/Engine/Utility/Tools/Hash.h
@@ -24,7 +24,7 @@ inline size_t hash(size_t seed, size_t value) {
 }
 
 template<typename T>
-size_t compression_value64(const T& value) {
+constexpr size_t _compression_64bit(const T& value) {
 	size_t result;
 	// sizeof(size_t)以下
 	if constexpr ((sizeof(T) <= sizeof(size_t))) {
@@ -33,7 +33,8 @@ size_t compression_value64(const T& value) {
 	}
 	else {
 		// 1度ハッシュ化して64bitに圧縮
-		result = std::hash<T>()(value);
+		// TがCV修飾の場合、定義なしになるのでCV修飾を外す
+		result = std::hash<std::remove_cv_t<T>>()(value);
 	}
 	return result;
 }
@@ -43,7 +44,7 @@ size_t hash_vector(const Array& array) {
 	size_t result = array.size();
 	size_t value;
 	for (auto itr = std::begin(array); itr != std::end(array); ++itr) {
-		value = compression_value64<typename Array::value_type>(*itr);
+		value = _compression_64bit<typename Array::value_type>(*itr);
 		result = hash(result, value);
 	}
 	return result;
@@ -54,7 +55,7 @@ size_t hash_vector(std::initializer_list<T>&& initializerList) {
 	size_t result = initializerList.size();
 	size_t value;
 	for (auto itr : initializerList) {
-		value = compression_value64<T>(itr);
+		value = _compression_64bit<T>(itr);
 		result = hash(result, value);
 	}
 	return result;


### PR DESCRIPTION
compression_value64(命名変更により現在の関数名は_compression_64bit)で、Tがcv修飾の場合に正しく処理できない問題を修正しました。
SortedPairのconstexpr対応を行いました。
CollisionCallback時の引数から実体のconstを削除しました。