### PR TITLE
軽微な追加、修正。

### DIFF
--- a/project/Engine/Module/World/Camera/Camera3D.cpp
+++ b/project/Engine/Module/World/Camera/Camera3D.cpp
@@ -66,7 +66,7 @@ void Camera3D::update_matrix() {
 #endif // _DEBUG
 }
 
-void Camera3D::set_command(uint32_t index) {
+void Camera3D::register_world(uint32_t index) {
 	auto& commandList = DirectXCommand::GetCommandList();
 	commandList->SetGraphicsRootConstantBufferView(
 		index, vpMatrixBuffer.get_resource()->GetGPUVirtualAddress()

--- a/project/Engine/Module/World/Camera/Camera3D.h
+++ b/project/Engine/Module/World/Camera/Camera3D.h
@@ -21,7 +21,7 @@ public:
 
 	void update_matrix();
 
-	void set_command(uint32_t index);
+	void register_world(uint32_t index);
 
 public:
 	void set_transform(const Transform3D& transform) noexcept;

--- a/project/Engine/Module/World/Collision/Collider/BaseCollider.cpp
+++ b/project/Engine/Module/World/Collision/Collider/BaseCollider.cpp
@@ -26,18 +26,6 @@ const std::string& BaseCollider::group() const noexcept {
 	}
 }
 
-void BaseCollider::set_on_collision(std::function<void(const BaseCollider* const)> function) {
-	onCollisionFunc = function;
-}
-
-void BaseCollider::set_on_collision_enter(std::function<void(const BaseCollider* const)> function) {
-	onCollisionEnterFunc = function;
-}
-
-void BaseCollider::set_on_collision_exit(std::function<void(const BaseCollider* const)> function) {
-	onCollisionExitFunc = function;
-}
-
 void BaseCollider::set_group_name(const std::string& name) {
 	groupName = &name;
 }

--- a/project/Engine/Module/World/Collision/Collider/BaseCollider.h
+++ b/project/Engine/Module/World/Collision/Collider/BaseCollider.h
@@ -1,6 +1,5 @@
 #pragma once
 
-#include <functional>
 #include <memory>
 #include <string>
 
@@ -24,19 +23,10 @@ public:
 	const std::string& group() const noexcept;
 
 public:
-	void set_on_collision(std::function<void(const BaseCollider* const)> function);
-	void set_on_collision_enter(std::function<void(const BaseCollider* const)> function);
-	void set_on_collision_exit(std::function<void(const BaseCollider* const)> function);
-
 	void set_group_name(const std::string& name);
 
 private:
 	const std::string* groupName;
-
-private:
-	std::function<void(const BaseCollider* const)> onCollisionFunc;
-	std::function<void(const BaseCollider* const)> onCollisionEnterFunc;
-	std::function<void(const BaseCollider* const)> onCollisionExitFunc;
 
 #ifdef _DEBUG
 public:

--- a/project/Engine/Module/World/Collision/Collider/SphereCollider.cpp
+++ b/project/Engine/Module/World/Collision/Collider/SphereCollider.cpp
@@ -18,6 +18,6 @@ void SphereCollider::set_radius(float radius_) {
 #endif // _DEBUG
 }
 
-float SphereCollider::get_radius() {
+float SphereCollider::get_radius() const {
 	return radius;
 }

--- a/project/Engine/Module/World/Collision/Collider/SphereCollider.h
+++ b/project/Engine/Module/World/Collision/Collider/SphereCollider.h
@@ -12,7 +12,7 @@ public:
 
 public:
 	void set_radius(float radius_);
-	float get_radius();
+	float get_radius() const;
 
 public:
 	constexpr std::string type() const override;

--- a/project/Engine/Module/World/Collision/CollisionFunctions.h
+++ b/project/Engine/Module/World/Collision/CollisionFunctions.h
@@ -2,7 +2,7 @@
 
 #include "Engine/Module/World/Collision/Collider/SphereCollider.h"
 
-bool Collision(SphereCollider* lhs, SphereCollider* rhs) {
+bool Collision(const SphereCollider* lhs, const SphereCollider* rhs) {
 	Vector3 distance = lhs->world_position() - rhs->world_position();
 	float range = lhs->get_radius() + rhs->get_radius();
 	return distance.length() <= range;

--- a/project/Engine/Module/World/WorldInstance/WorldInstance.h
+++ b/project/Engine/Module/World/WorldInstance/WorldInstance.h
@@ -87,7 +87,7 @@ public:
 	const Matrix4x4& world_matrix() const { return worldMatrix; };
 
 	/// <summary>
-	/// WorldPosiitonの取得
+	/// WorldPositionの取得
 	/// </summary>
 	/// <returns></returns>
 	Vector3 world_position() const { return Transform3D::ExtractPosition(worldMatrix); };

--- a/project/Library/Math/Color.cpp
+++ b/project/Library/Math/Color.cpp
@@ -8,10 +8,6 @@
 #include <imgui.h>
 #endif // _DEBUG
 
-const unsigned int Color::hex() const {
-	return (std::uint32_t(red * 255) << 24) + (std::uint32_t(green * 255) << 16) + (std::uint32_t(blue * 255) << 8) + std::uint32_t(alpha * 255);
-}
-
 #ifdef _DEBUG
 void Color::debug_gui3() noexcept(false) {
 	ImGui::ColorEdit3("Color", &(this->red), ImGuiColorEditFlags_Float | ImGuiColorEditFlags_AlphaPreview | ImGuiColorEditFlags_InputRGB);
@@ -21,18 +17,6 @@ void Color::debug_gui4() noexcept(false) {
 }
 #endif // _DEBUG
 
-unsigned int Color::ToHex(unsigned int red, unsigned int green, unsigned int blue, unsigned int alpha) {
-	return (red << 24) + (green << 16) + (blue << 8) + alpha;
-}
-
-//unsigned int Color::LerpC(unsigned int hex1, unsigned int hex2, float t) {
-//	return Color::ToHex(
-//		std::clamp(Lerp((hex1 >> 24) & 0x000000ff, (hex2 >> 24) & 0x000000ff, t), 0x0u, 0xffffffff),
-//		std::clamp(Lerp((hex1 >> 16) & 0x000000ff, (hex2 >> 16) & 0x000000ff, t), 0x0u, 0xffffffff),
-//		std::clamp(Lerp((hex1 >> 8) & 0x000000ff, (hex2 >> 8) & 0x000000ff, t), 0x0u, 0xffffffff),
-//		std::clamp(Lerp(((hex1 >> 0) & 0x000000ff), (hex2 >> 0) & 0x000000ff, t), 0x0u, 0xffffffff));
-//}
-//
 //Color Color::LerpC(const Color& color1, const Color& color2, float t) {
 //	return Color{
 //		Lerp(color1.red, color2.red, t),

--- a/project/Library/Math/Color.h
+++ b/project/Library/Math/Color.h
@@ -39,31 +39,14 @@ public:
 	float blue{ 1.0f }; // 青[0, 1]
 	float alpha{ 1.0f }; // アルファ[0, 1]
 
-public:
-	/// <summary>
-	/// 削除予定
-	/// </summary>
-	/// <returns></returns>
-	[[deprecated]] const unsigned int hex() const;
 #ifdef _DEBUG
+public:
 	void debug_gui3() noexcept(false);
 
 	void debug_gui4() noexcept(false);
 #endif // _DEBUG
 
 public:
-	/// <summary>
-	/// 削除予定
-	/// </summary>
-	/// <returns></returns>
-	[[deprecated]] static unsigned int ToHex(unsigned int red, unsigned int green, unsigned int blue, unsigned int alpha);
-
-	/// <summary>
-	/// 削除予定
-	/// </summary>
-	/// <returns></returns>
-	[[deprecated]] static unsigned int LerpC(unsigned int hex1, unsigned int hex2, float t);
-
 	/// <summary>
 	/// 色の線形補間(Easing.hが存在しないため未実装)
 	/// </summary>
@@ -95,7 +78,22 @@ constexpr Color::Color(float _red, float _green, float _blue, float _alpha) noex
 	alpha = _alpha;
 }
 
-// TODO
+/// <summary>
+/// Color定数
+/// </summary>
 namespace CColor {
+
+constexpr Color WHITE{ 1.0f, 1.0f, 1.0f, 1.0f };
+constexpr Color BLACK{ 0.0f, 0.0f, 0.0f, 1.0f };
+constexpr Color RED{ 1.0f, 0.0f, 0.0f, 1.0f };
+constexpr Color GREEN{ 0.0f, 1.0f, 0.0f, 1.0f };
+constexpr Color BLUE{ 0.0f, 0.0f, 1.0f, 1.0f };
+
+constexpr Color YELLOW{ 1.0f, 1.0f, 0.0f, 1.0f };
+constexpr Color MAGENTA{ 1.0f, 0.0f, 1.0f, 1.0f };
+constexpr Color CYAN{ 0.0f, 1.0f, 1.0f, 1.0f };
+
+constexpr Color ZERO{ 0.0f, 0.0f, 0.0f, 0.0f };
+constexpr Color ZERO_WHITE{ 1.0f, 1.0f, 1.0f, 0.0f };
 
 }

--- a/project/Library/Math/Vector2.h
+++ b/project/Library/Math/Vector2.h
@@ -316,6 +316,7 @@ constexpr const Vector2 Vector2::Rotate(const Vector2& vector, const float sinTh
 /// Vector2定数
 /// </summary>
 namespace CVector2 {
+
 constexpr Vector2 BASIS_X = Vector2{ 1.0f, 0.0f }; // x(1.0f), y(0.0f)
 constexpr Vector2 BASIS_Y = Vector2{ 0.0f, 1.0f }; // x(0.0f), y(1.0f)
 constexpr Vector2 ZERO = Vector2{ 0.0f, 0.0f }; // x(0.0f), y(0.0f)
@@ -323,4 +324,10 @@ constexpr Vector2 BASIS = Vector2{ 1.0f, 1.0f }; // x(1.0f), y(1.0f)
 constexpr Vector2 INFINTY = Vector2{ std::numeric_limits<float>::infinity(),std::numeric_limits<float>::infinity() };
 constexpr Vector2 INFINTY_X = Vector2{ std::numeric_limits<float>::infinity(),0 };
 constexpr Vector2 INFINTY_Y = Vector2{ 0, std::numeric_limits<float>::infinity() };
+
+constexpr Vector2 FORWARD{ BASIS_X };
+constexpr Vector2 BACKWARD{ -FORWARD };
+constexpr Vector2 UP{ BASIS_Y };
+constexpr Vector2 BACK{ -UP };
+
 };

--- a/project/Library/Math/Vector3.h
+++ b/project/Library/Math/Vector3.h
@@ -308,13 +308,22 @@ constexpr Vector3 Vector3::Bezier(const Vector3& initial, const Vector3& control
 /// Vector3定数
 /// </summary>
 namespace CVector3 {
-	constexpr Vector3 BASIS{ 1.0f, 1.0f, 1.0f }; // x(1.0f), y(1.0f), z(1.0f)
-	constexpr Vector3 BASIS_X{ 1.0f, 0.0f, 0.0f }; // x(1.0f), y(0.0f), z(0.0f)
-	constexpr Vector3 BASIS_Y{ 0.0f, 1.0f, 0.0f }; // x(0.0f), y(1.0f), z(0.0f)
-	constexpr Vector3 BASIS_Z{ 0.0f, 0.0f, 1.0f }; // x(0.0f), y(0.0f), z(1.0f)
-	constexpr Vector3 ZERO{ 0.0f, 0.0f, 0.0f }; // x(0.0f), y(0.0f), z(0.0f)
-	constexpr Vector3 INFINTY{ std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity() };
-	constexpr Vector3 INFINTY_X{ std::numeric_limits<float>::infinity(), 0, 0 };
-	constexpr Vector3 INFINTY_Y{ 0, std::numeric_limits<float>::infinity(), 0 };
-	constexpr Vector3 INFINTY_Z{ 0, 0, std::numeric_limits<float>::infinity() };
+
+constexpr Vector3 BASIS{ 1.0f, 1.0f, 1.0f }; // x(1.0f), y(1.0f), z(1.0f)
+constexpr Vector3 BASIS_X{ 1.0f, 0.0f, 0.0f }; // x(1.0f), y(0.0f), z(0.0f)
+constexpr Vector3 BASIS_Y{ 0.0f, 1.0f, 0.0f }; // x(0.0f), y(1.0f), z(0.0f)
+constexpr Vector3 BASIS_Z{ 0.0f, 0.0f, 1.0f }; // x(0.0f), y(0.0f), z(1.0f)
+constexpr Vector3 ZERO{ 0.0f, 0.0f, 0.0f }; // x(0.0f), y(0.0f), z(0.0f)
+constexpr Vector3 INFINTY{ std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity(), std::numeric_limits<float>::infinity() };
+constexpr Vector3 INFINTY_X{ std::numeric_limits<float>::infinity(), 0, 0 };
+constexpr Vector3 INFINTY_Y{ 0, std::numeric_limits<float>::infinity(), 0 };
+constexpr Vector3 INFINTY_Z{ 0, 0, std::numeric_limits<float>::infinity() };
+
+constexpr Vector3 FORWARD{ BASIS_Z };
+constexpr Vector3 BACKWARD{ -FORWARD };
+constexpr Vector3 UP{ BASIS_Y };
+constexpr Vector3 BACK{ -UP };
+constexpr Vector3 RIGHT{ BASIS_X };
+constexpr Vector3 LEFT{ -RIGHT };
+
 }

--- a/project/TestCode/SceneDemo.cpp
+++ b/project/TestCode/SceneDemo.cpp
@@ -173,7 +173,7 @@ void SceneDemo::late_update() {
 void SceneDemo::draw() const {
 	renderPath->begin();
 	directionalLight->register_world(3);
-	camera3D->set_command(1);
+	camera3D->register_world(1);
 	parent->draw();
 	child->draw();
 #ifdef _DEBUG
@@ -183,7 +183,7 @@ void SceneDemo::draw() const {
 #endif // _DEBUG
 
 	renderPath->next();
-	camera3D->set_command(1);
+	camera3D->register_world(1);
 	particleSystem->draw();
 
 	renderPath->next();


### PR DESCRIPTION
Camera3D::set_commandをCamera3D::register_worldに命名変更を行いました。
Colliderの定義内に存在したコールバック関数オブジェクトを削除しました。
SphereCollider::get_radiusにconst指定を行いました。
Colorクラス内に存在した、今後使用しない関数を削除しました。
Color関連の定数namespaceとして、CColorを追加しました。
CVector2及びCVector3に変数を追加しました。
その他軽微な修正を行いました。