### PR TITLE
JsonAsset使用時、ファイルが存在しない場合の挙動を変更しました。

### DIFF
--- a/Engine/Assets/Json/JsonAsset.cpp
+++ b/Engine/Assets/Json/JsonAsset.cpp
@@ -23,6 +23,11 @@ void JsonAsset::load(const std::filesystem::path& file) {
 		filePath = DEFAULT_DIRECTORY / file;
 	}
 
+	if (!std::filesystem::exists(filePath)) {
+		Warning(L"File-\'{}\' is not found.", filePath.stem().native());
+		return;
+	}
+
 	std::ifstream ifstream{ filePath };
 
 	if (ifstream.fail()) {

--- a/Engine/Debug/Editor/Core/EditorGizmo.cpp
+++ b/Engine/Debug/Editor/Core/EditorGizmo.cpp
@@ -167,8 +167,8 @@ void EditorGizmo::scene_header() {
 
 		ImGui::PopStyleVar(1);
 		ImGui::PopFont();
-		ImGui::EndChild();
 	}
+	ImGui::EndChild();
 }
 
 #endif // DEBUG_FEATURES_ENABLE

--- a/Engine/Debug/Editor/EditorMain.cpp
+++ b/Engine/Debug/Editor/EditorMain.cpp
@@ -55,16 +55,25 @@ void EditorMain::Setup() {
 	IRemoteObject::Setup(instance.sceneView);
 	instance.sceneView.setup(instance.gizmo, instance.hierarchy);
 	instance.inspector.setup(instance.selectObject);
+	instance.hierarchy.setup(instance.selectObject, instance.sceneView);
 
+	std::filesystem::path filePath = "./Game/DebugData/Editor.json";
 	JsonAsset json;
+	if (!std::filesystem::exists(filePath)) {
+		instance.isActiveEditor = false;
+		Warning("The file required to start the editor was not found.");
+	}
+
 	json.load("./Game/DebugData/Editor.json");
 	std::string sceneFileName = json.try_emplace<std::string>("LastLoadedScene");
 	instance.hierarchy.load(std::format("./Game/Core/Scene/{}.json", sceneFileName));
-	instance.hierarchy.setup(instance.selectObject, instance.sceneView);
 }
 
 void EditorMain::DrawBase() {
 	EditorMain& instance = GetInstance();
+	if (!instance.isActiveEditor) {
+		return;
+	}
 
 	if (instance.switchSceneName.has_value()) {
 		// シーンビューを未設定に設定
@@ -146,6 +155,10 @@ void EditorMain::Draw() {
 	}
 
 	EditorHierarchyDandD::ExecuteReparent();
+}
+
+void EditorMain::SetActiveEditor(bool isActive) {
+	GetInstance().isActiveEditor = isActive;
 }
 
 bool EditorMain::IsHoverEditorWindow() {

--- a/Engine/Debug/Editor/EditorMain.h
+++ b/Engine/Debug/Editor/EditorMain.h
@@ -25,6 +25,9 @@ public:
 	static void DrawBase();
 	static void Draw();
 
+public:
+	static void SetActiveEditor(bool isActive);
+
 	static bool IsHoverEditorWindow();
 
 private:

--- a/Engine/Debug/Editor/Window/EditorHierarchy.cpp
+++ b/Engine/Debug/Editor/Window/EditorHierarchy.cpp
@@ -27,12 +27,9 @@
 void EditorHierarchy::setup(Reference<EditorSelectObject> select_, Reference<EditorSceneView> sceneView_) {
 	select = select_;
 	sceneView = sceneView_;
-	scene->setup();
 }
 
 void EditorHierarchy::finalize() {
-	JsonAsset json{ "./Game/DebugData/Editor.json" };
-	json.get()["LastLoadedScene"] = scene->name();
 	scene.reset();
 }
 
@@ -48,6 +45,8 @@ void EditorHierarchy::load(std::filesystem::path file) {
 	scene = EditorSceneSerializer::CreateRemoteScene(json.try_emplace<nlohmann::json>("Scene"));
 
 	Reference<BaseScene> currentScene = SceneManager::GetCurrentScene();
+
+	scene->setup();
 }
 
 nlohmann::json EditorHierarchy::save() const {


### PR DESCRIPTION
Editorを使用するかのフラグを設定できるよう追加しました。
Game/DebugData/Editor.jsonが存在しない場合に、アプリがクラッシュしないよう修正しました。