### PR TITLE
Editorの機能改修及び不具合修正

### DIFF
--- a/Engine/Debug/Editor/Command/EditorCommandInvoker.cpp
+++ b/Engine/Debug/Editor/Command/EditorCommandInvoker.cpp
@@ -1,9 +1,9 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "EditorCommandInvoker.h"
 
-#include "IEditorCommand.h"
 #include "Engine/Application/Logger.h"
+#include "IEditorCommand.h"
 
 using namespace szg;
 

--- a/Engine/Debug/Editor/EditorMain.cpp
+++ b/Engine/Debug/Editor/EditorMain.cpp
@@ -7,13 +7,13 @@
 #include <imgui.h>
 
 #include "./Adapter/EditorAssetSaver.h"
-#include "./Core/EditorAssetContentsCollector.h"
-#include "./Core/EditorDandDManager.h"
-#include "./Core/EditorSceneAssetCollection.h"
 #include "./Command/EditorCommandInvoker.h"
 #include "./Command/EditorCreateObjectCommand.h"
 #include "./Command/EditorDeleteObjectCommand.h"
 #include "./Command/EditorSelectCommand.h"
+#include "./Core/EditorAssetContentsCollector.h"
+#include "./Core/EditorDandDManager.h"
+#include "./Core/EditorSceneAssetCollection.h"
 #include "./Window/AssetBrowser/Optimizer/FontAtlas/FontAtlasBuilderManager.h"
 #include "./Window/Logger/EditorLogWindow.h"
 
@@ -26,12 +26,11 @@ using namespace szg;
 
 void EditorMain::Initialize() {
 	EditorMain& instance = GetInstance();
-	instance.sceneView.initialize(true);
-	instance.inspector.initialize();
 	instance.sceneList.initialize();
-	EditorLogWindow::Initialize(true);
+
+	instance.sceneView.initialize();
 	instance.renderDAG.initialize();
-	instance.screenResult.initialize(true);
+	instance.screenResult.initialize();
 
 	FontAtlasBuilderManager::Initialize();
 }
@@ -45,6 +44,33 @@ void EditorMain::Finalize() {
 
 	nlohmann::json json;
 	json["LastLoadedScene"] = instance.hierarchy.current_scene_name();
+
+	u32 windowStateBit{ 0 };
+	if (instance.sceneView.is_active()) {
+		windowStateBit |= (1 << 0);
+	}
+	if (instance.hierarchy.is_active()) {
+		windowStateBit |= (1 << 1);
+	}
+	if (instance.inspector.is_active()) {
+		windowStateBit |= (1 << 2);
+	}
+	if (instance.renderDAG.is_active()) {
+		windowStateBit |= (1 << 3);
+	}
+	if (instance.assetBrowser.is_active()) {
+		windowStateBit |= (1 << 4);
+	}
+	if (EditorLogWindow::IsActive()) {
+		windowStateBit |= (1 << 5);
+	}
+	if (instance.screenResult.is_active()) {
+		windowStateBit |= (1 << 6);
+	}
+	if (instance.customEditorManager) {
+		windowStateBit |= instance.customEditorManager->get_window_state_bit();
+	}
+	json["WindowStateBit"] = windowStateBit;
 
 	std::filesystem::path filePath = "./Game/DebugData/Editor.json";
 	auto parentPath = filePath.parent_path();
@@ -79,6 +105,33 @@ void EditorMain::Setup() {
 		// 直前に開いていたシーン情報がある場合はそれを開く
 		JsonAsset json{ "./Game/DebugData/Editor.json" };
 		sceneName = json.try_emplace<std::string>("LastLoadedScene");
+
+		u32 windowStateBit = json.get().value("WindowStateBit", static_cast<u32>(-1));
+		if (windowStateBit & (1 << 0)) {
+			instance.sceneView.set_active(true);
+		}
+		if (windowStateBit & (1 << 1)) {
+			instance.hierarchy.set_active(true);
+		}
+		if (windowStateBit & (1 << 2)) {
+			instance.inspector.set_active(true);
+		}
+		if (windowStateBit & (1 << 3)) {
+			instance.renderDAG.set_active(true);
+		}
+		if (windowStateBit & (1 << 4)) {
+			instance.assetBrowser.set_active(true);
+		}
+		if (windowStateBit & (1 << 5)) {
+			EditorLogWindow::SetActive(true);
+		}
+		if (windowStateBit & (1 << 6)) {
+			instance.screenResult.set_active(true);
+		}
+
+		if (instance.customEditorManager) {
+			instance.customEditorManager->setup_window_active(windowStateBit);
+		}
 	}
 	else {
 		// ない場合
@@ -272,6 +325,7 @@ void szg::EditorMain::draw_menu_bar(r32& menuHight) {
 			sceneView.draw_menu("Scene");
 			hierarchy.draw_menu("Hierarchy");
 			inspector.draw_menu("Inspector");
+			assetBrowser.draw_menu("Asset");
 			EditorLogWindow::DrawMenu("Log");
 			renderDAG.draw_menu("RenderDAG");
 

--- a/Engine/Debug/Editor/EditorMain.h
+++ b/Engine/Debug/Editor/EditorMain.h
@@ -67,14 +67,15 @@ private:
 
 	std::optional<std::string> switchSceneName;
 
-	EditorSceneView sceneView;
-	EditorScreenResult screenResult;
-	EditorHierarchy hierarchy;
-	EditorInspector inspector;
 	EditorGizmo gizmo;
 	EditorSelectObject selectObject;
 	EditorDeletedObjectPool deletedPool;
 	EditorSceneList sceneList;
+
+	EditorSceneView sceneView;
+	EditorScreenResult screenResult;
+	EditorHierarchy hierarchy;
+	EditorInspector inspector;
 	EditorRenderDAG renderDAG;
 	EditorAssetBrowser assetBrowser;
 

--- a/Engine/Debug/Editor/Window/AssetBrowser/EditorAssetBrowser.cpp
+++ b/Engine/Debug/Editor/Window/AssetBrowser/EditorAssetBrowser.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "EditorAssetBrowser.h"
 
@@ -14,6 +14,10 @@
 using namespace szg;
 
 void EditorAssetBrowser::draw() {
+	if (!isActive) {
+		return;
+	}
+
 	ImGui::Begin("Asset", &isActive);
 	update_focus();
 

--- a/Engine/Debug/Editor/Window/Hierarchy/EditorHierarchy.cpp
+++ b/Engine/Debug/Editor/Window/Hierarchy/EditorHierarchy.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "EditorHierarchy.h"
 
@@ -41,8 +41,6 @@ void EditorHierarchy::update_preview() {
 }
 
 void EditorHierarchy::load(const std::string& sceneName) {
-	isActive = true;
-
 	scene = EditorSceneSerializer::CreateRemoteScene(sceneName);
 
 	scene->setup();
@@ -100,7 +98,8 @@ void EditorHierarchy::draw() {
 			}
 			ImGui::SeparatorText("Instance");
 			if (ImGui::MenuItem("WorldInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object && 
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -111,7 +110,8 @@ void EditorHierarchy::draw() {
 			}
 			ImGui::SeparatorText("Rendering");
 			if (ImGui::MenuItem("StaticMeshInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -121,7 +121,8 @@ void EditorHierarchy::draw() {
 				}
 			}
 			if (ImGui::MenuItem("SkinningMeshInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -131,7 +132,8 @@ void EditorHierarchy::draw() {
 				}
 			}
 			if (ImGui::MenuItem("Rect3dInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -141,7 +143,8 @@ void EditorHierarchy::draw() {
 				}
 			}
 			if (ImGui::MenuItem("StringRectInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -153,7 +156,8 @@ void EditorHierarchy::draw() {
 
 			ImGui::SeparatorText("Camera");
 			if (ImGui::MenuItem("CameraInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -165,7 +169,8 @@ void EditorHierarchy::draw() {
 
 			ImGui::SeparatorText("Light");
 			if (ImGui::MenuItem("DirectionalLightInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -175,7 +180,8 @@ void EditorHierarchy::draw() {
 				}
 			}
 			if (ImGui::MenuItem("PointLightInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -187,7 +193,8 @@ void EditorHierarchy::draw() {
 
 			ImGui::SeparatorText("Collider");
 			if (ImGui::MenuItem("AABBColliderInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,
@@ -197,7 +204,8 @@ void EditorHierarchy::draw() {
 				}
 			}
 			if (ImGui::MenuItem("SphereColliderInstance")) {
-				if (select->get_item_mut().object) {
+				if (select->get_item_mut().object &&
+					select->get_item_mut().object->instance_type() != InstanceType::DebugScene) {
 					EditorCommandInvoker::Execute(
 						std::make_unique<EditorCreateObjectCommand>(
 							select->get_item_mut().object,

--- a/Engine/Debug/Editor/Window/IEditorWindow.cpp
+++ b/Engine/Debug/Editor/Window/IEditorWindow.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "IEditorWindow.h"
 
@@ -10,12 +10,7 @@ using namespace szg;
 
 void IEditorWindow::draw_menu(string_literal name) {
 	std::string itemName = name;
-	if (isActive) {
-		itemName += "\ue5ca";
-	}
-	if (ImGui::MenuItem(itemName.c_str())) {
-		isActive = true;
-	}
+	ImGui::MenuItem(itemName.c_str(), nullptr, &isActive);
 }
 
 bool IEditorWindow::is_active() const {

--- a/Engine/Debug/Editor/Window/Inspector/EditorInspector.cpp
+++ b/Engine/Debug/Editor/Window/Inspector/EditorInspector.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "EditorInspector.h"
 
@@ -8,10 +8,6 @@
 #include "../../RemoteObject/IRemoteObject.h"
 
 using namespace szg;
-
-void EditorInspector::initialize() {
-	isActive = true;
-}
 
 void EditorInspector::setup(Reference<EditorSelectObject> selectObject_) {
 	selectObject = selectObject_;

--- a/Engine/Debug/Editor/Window/Inspector/EditorInspector.h
+++ b/Engine/Debug/Editor/Window/Inspector/EditorInspector.h
@@ -12,7 +12,6 @@ class EditorSelectObject;
 
 class EditorInspector : public IEditorWindow {
 public:
-	void initialize();
 	void setup(Reference<EditorSelectObject> selectObject_);
 
 	void draw() override;

--- a/Engine/Debug/Editor/Window/Logger/EditorLogWindow.cpp
+++ b/Engine/Debug/Editor/Window/Logger/EditorLogWindow.cpp
@@ -1,4 +1,4 @@
-﻿#ifdef DEBUG_FEATURES_ENABLE
+#ifdef DEBUG_FEATURES_ENABLE
 
 #include "EditorLogWindow.h"
 
@@ -19,11 +19,6 @@ void EditorLogWindow::Allocate() {
 	instance.logStates[static_cast<u8>(Logger::Level::Error)] = { true, 0, "\ue99a",{ 0.8f, 0.1f, 0.1f, 1.0f } };
 	instance.logStates[static_cast<u8>(Logger::Level::Critical)] = { true, 0, "\uf5cf",{ 1.0f, 0.5f, 0.5f, 1.0f } };
 	instance.logStates[static_cast<u8>(Logger::Level::Assert)] = { true, 0, "\uf5cf",{ 1.0f, 0.5f, 0.5f, 1.0f } };
-}
-
-void EditorLogWindow::Initialize(bool isActive_) {
-	auto& instance = GetInstance();
-	instance.isActive = isActive_;
 }
 
 void EditorLogWindow::Draw() {
@@ -138,6 +133,18 @@ void EditorLogWindow::AppendLogEntry(Logger::Level level, const std::string& mes
 		--instance.logStates[static_cast<u8>(tmp.level)].numLogs;
 		instance.logs.pop_front();
 	}
+}
+
+void szg::EditorLogWindow::SetActive(bool isActive_) {
+	auto& instance = GetInstance();
+	std::lock_guard lock{ instance.mutex };
+	instance.isActive = isActive_;
+}
+
+bool szg::EditorLogWindow::IsActive() {
+	auto& instance = GetInstance();
+	std::lock_guard lock{ instance.mutex };
+	return instance.isActive;
 }
 
 #endif // DEBUG_FEATURES_ENABLE

--- a/Engine/Debug/Editor/Window/Logger/EditorLogWindow.h
+++ b/Engine/Debug/Editor/Window/Logger/EditorLogWindow.h
@@ -32,7 +32,6 @@ private:
 
 public:
 	static void Allocate();
-	static void Initialize(bool isActive_);
 
 	static void Draw();
 	static void DrawMenu(string_literal label);
@@ -40,6 +39,10 @@ public:
 	void draw() override;
 
 	static void AppendLogEntry(Logger::Level level, const std::string& message);
+
+public:
+	static void SetActive(bool isActive_);
+	static bool IsActive();
 
 private:
 	std::array<LogState, Logger::LevelCount> logStates;

--- a/Engine/Debug/Editor/Window/RenderDAG/EditorRenderDAG.cpp
+++ b/Engine/Debug/Editor/Window/RenderDAG/EditorRenderDAG.cpp
@@ -1,4 +1,4 @@
-﻿#include "EditorRenderDAG.h"
+#include "EditorRenderDAG.h"
 
 #ifdef DEBUG_FEATURES_ENABLE
 
@@ -22,10 +22,6 @@
 #include "Engine/Application/Logger.h"
 
 using namespace szg;
-
-EditorRenderDAG::EditorRenderDAG() {
-	isActive = true;
-}
 
 void EditorRenderDAG::initialize() {
 	imNodeFlow = std::make_unique<ImFlow::ImNodeFlow>();

--- a/Engine/Debug/Editor/Window/RenderDAG/EditorRenderDAG.h
+++ b/Engine/Debug/Editor/Window/RenderDAG/EditorRenderDAG.h
@@ -21,7 +21,7 @@ class EditorHierarchy;
 
 class EditorRenderDAG final : public IEditorWindow {
 public:
-	EditorRenderDAG();
+	EditorRenderDAG() = default;
 	~EditorRenderDAG() override = default;
 
 	SZG_CLASS_MOVE_ONLY(EditorRenderDAG)

--- a/Engine/Debug/Editor/Window/SceneView/EditorSceneView.cpp
+++ b/Engine/Debug/Editor/Window/SceneView/EditorSceneView.cpp
@@ -21,8 +21,7 @@
 
 using namespace szg;
 
-void EditorSceneView::initialize(bool isActive_) {
-	isActive = isActive_;
+void EditorSceneView::initialize() {
 	screenResultTexture.initialize();
 
 	std::shared_ptr<StaticMeshForwardPipeline> staticMeshNode = std::make_shared<StaticMeshForwardPipeline>();

--- a/Engine/Debug/Editor/Window/SceneView/EditorSceneView.h
+++ b/Engine/Debug/Editor/Window/SceneView/EditorSceneView.h
@@ -37,7 +37,7 @@ public:
 	SZG_CLASS_MOVE_ONLY(EditorSceneView)
 
 public:
-	void initialize(bool isActive_);
+	void initialize();
 	void setup(Reference<EditorGizmo> gizmo_, Reference<const EditorHierarchy> hierarchy_);
 
 	void update();

--- a/Engine/Debug/Editor/Window/ScreenResult/EditorScreenResult.cpp
+++ b/Engine/Debug/Editor/Window/ScreenResult/EditorScreenResult.cpp
@@ -10,9 +10,7 @@
 
 using namespace szg;
 
-void EditorScreenResult::initialize(bool isActive_) {
-	isActive = isActive_;
-
+void EditorScreenResult::initialize() {
 	screenResultCpy.initialize();
 }
 

--- a/Engine/Debug/Editor/Window/ScreenResult/EditorScreenResult.h
+++ b/Engine/Debug/Editor/Window/ScreenResult/EditorScreenResult.h
@@ -10,7 +10,7 @@ namespace szg {
 
 class EditorScreenResult final : public IEditorWindow {
 public:
-	void initialize(bool isActive_);
+	void initialize();
 
 	void draw() override;
 


### PR DESCRIPTION
EditorWindowについて、前回のセッションのウィンドウの表示/非表示を保存するよう変更しました。
Hierarchyウィンドウで、Sceneを選択した状態でRemoteInstanceを作成しようとした際にクラッシュする不具合を修正しました。
 AssetBrowserのMenuが表示されていない不具合を修正しました。